### PR TITLE
Storing Response in ApiException

### DIFF
--- a/src/Beanstream/Exception.php
+++ b/src/Beanstream/Exception.php
@@ -68,4 +68,16 @@ class ConnectorException extends Exception {}
 /**
  * ApiException class
  */
-class ApiException extends Exception {}
+class ApiException extends Exception {
+	protected $response;
+
+	public function __construct($message, $code = 0, $response = null) {
+		$this->response = $response;
+
+		parent::__construct($message, $code);
+	}
+
+	public function getResponse() {
+		return $this->response;
+	}
+}

--- a/src/Beanstream/communications/HttpConnector.php
+++ b/src/Beanstream/communications/HttpConnector.php
@@ -115,7 +115,7 @@ class HttpConnector {
         
 		//check for return errors from the API
         if (isset($res['code']) && 1 < $res['code'] && !($req['http_code'] >= 200 && $req['http_code'] < 300)) {
-            throw new ApiException($res['message'], $res['code']);
+            throw new ApiException($res['message'], $res['code'], $res);
         }
         
         return $res;


### PR DESCRIPTION
Beanstream API can throw a plethora of exceptions stating issues causing declined payments as well as issues with certain fields.

It may be necessary to parse these errors and map them to internal errors at a more granular level than error codes. For example, Error 314 can pertain to any payment field errors. It may be necessary to display problematic errors to the user after parsing the response.

ApiException now takes a $response parameter defaulting to null before initializing the parent Exception. The ApiException's response variable is initialized within the HttpConnector when a response is received.
