### PR TITLE
Update endpoints to support api.na.bambora.com platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ require 'vendor/autoload.php';
 $merchant_id = ''; //INSERT MERCHANT ID (must be a 9 digit string)
 $api_key = ''; //INSERT API ACCESS PASSCODE
 $api_version = 'v1'; //default
-$platform = 'www'; //default
+$platform = 'api'; //default
 
 //Create Beanstream Gateway
 $beanstream = new \Beanstream\Gateway($merchant_id, $api_key, $platform, $api_version);
@@ -116,3 +116,13 @@ for payment and search passcodes, *configuration -> payment profile configuratio
 Beanstream requires the *province* field submitted along with *billing* data to be a two-letter code. It only requires it when
 the specified *country* is *US* or *CA*, for other country codes set it to *--* (two dashes) even if the corresponding country 
 does have states or provinces.
+
+
+### Backwards Compatibility
+The default `$platform` value assigned is `'api'`, which sends your requests to the endpoint `'api.na.bambora.com'`. The ensure backwards compatibility, you may assign `$platform = 'www'` which will send your requests to the legacy endpoint `'www.beanstream.com/api'`.
+
+
+### Ensuring TLS 1.2-Only Compatibility
+If you would like to test compatibility with the TLS 1.2-only environment, assign `$platform = 'tls12-api'`, instead of `'api'`; This will point your requests to the endpoint `'tls12-api.na.bambora.com'`. Please be advised that this endpoint is provided for a limited time, and is intended for integration compatibility testing only, and is not intended for any type of load tests. More details can be found on the [Bambora North America Knowledge Base](https://help.na.bambora.com/hc/en-us/articles/115015460087-TLS-Upgrade-TLS-1-2).
+
+

--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ The default `$platform` value assigned is `'api'`, which sends your requests to 
 
 
 ### Ensuring TLS 1.2-Only Compatibility
-If you would like to test compatibility with the TLS 1.2-only environment, assign `$platform = 'tls12-api'`, instead of `'api'`; This will point your requests to the endpoint `'tls12-api.na.bambora.com'`. Please be advised that this endpoint is provided for a limited time, and is intended for integration compatibility testing only, and is not intended for any type of load tests. More details can be found on the [Bambora North America Knowledge Base](https://help.na.bambora.com/hc/en-us/articles/115015460087-TLS-Upgrade-TLS-1-2).
+If you would like to test compatibility with the LIVE TLS 1.2-only environment, assign `$platform = 'tls12-api'`, instead of `'api'`; This will point your requests to the endpoint `'tls12-api.na.bambora.com'`. Please be advised that this endpoint is provided for a limited time, and is intended for integration compatibility testing only, and is not intended for any type of load tests. More details can be found on the [Bambora North America Knowledge Base](https://help.na.bambora.com/hc/en-us/articles/115015460087-TLS-Upgrade-TLS-1-2).
 
 

--- a/src/Beanstream/Configuration.php
+++ b/src/Beanstream/Configuration.php
@@ -19,7 +19,7 @@ class Configuration {
      * 
      * @var string $_platform
      */
-	protected $_platform = 'www'; //default
+	protected $_platform = 'api'; //default
 
     /**
      * Configuration: Merchant ID

--- a/src/Beanstream/communications/Endpoints.php
+++ b/src/Beanstream/communications/Endpoints.php
@@ -10,7 +10,8 @@ class Endpoints {
 	/**
 	 * Endpoints: Set BASE API Endpoint URL with inline {0} platform variable
 	 */
-	CONST BASE_URL = 'https://{0}.beanstream.com/api';
+	CONST BASE_URL_BAMBORANA = 'https://{0}.na.bambora.com';
+	CONST BASE_URL_BEANSTREAM = 'https://{0}.beanstream.com';  //keeping beanstream endpoint for backwards compatibility when $platform = 'www'
 
 	/**
 	 * Endpoint URL holders
@@ -65,25 +66,27 @@ class Endpoints {
      * @param string $version API Version
      */
 	function __construct($platform, $version) {
-		
+			
 		//assign endpoints
+		$baseUrl = ($platform == 'www' ? self::BASE_URL_BEANSTREAM . '/api' : self::BASE_URL_BAMBORANA);
+		
 		//payments
-		$this->basePaymentsURL = self::BASE_URL . '/{1}/payments';
+		$this->basePaymentsURL = $baseUrl . '/{1}/payments';
 		$this->preAuthCompletionsURL = $this->basePaymentsURL . '/{2}/completions';
 		$this->returnsURL = $this->basePaymentsURL . '/{2}/returns';
 		$this->unreferencedReturnsURL = $this->basePaymentsURL . '/0/returns';
 		$this->voidsURL = $this->basePaymentsURL . '/{2}/void';
 		$this->continuationsURL = $this->basePaymentsURL . '/{2}/continue';
-		$this->tokenizationURL = 'https://{0}.beanstream.com/scripts/tokenization/tokens';
-
+		$this->tokenizationURL = ($platform == 'www' ? self::BASE_URL_BEANSTREAM . '/scripts/tokenization/tokens' : $baseUrl . '/scripts/tokenization/tokens');
+		
 		//profiles
-		$this->baseProfilesURL = self::BASE_URL . '/{1}/profiles';
+		$this->baseProfilesURL = $baseUrl . '/{1}/profiles';
 		$this->profileURI = $this->baseProfilesURL . '/{2}';
 		$this->cardsURI = $this->profileURI . '/cards';
 		$this->cardURI = $this->cardsURI . '/{3}';
 
 		//reporting
-		$this->reportsURL = self::BASE_URL . '/{1}/reports';
+		$this->reportsURL = $baseUrl . '/{1}/reports';
 		$this->getPaymentURL = $this->basePaymentsURL . '/{2}';
 		
 		//assign incoming platform and version
@@ -91,6 +94,7 @@ class Endpoints {
 		$this->_version = $version;
 		
 	}
+
 
 	//methods to build out and return endpoints
 	//payments

--- a/src/Beanstream/examples.php
+++ b/src/Beanstream/examples.php
@@ -1,4 +1,4 @@
-<?php
+<pre><?php
 //BEANSTREAM REST API SDK USAGE EXAMPLES	
 
 //get Beanstream Gateway
@@ -8,7 +8,7 @@ require_once 'Gateway.php';
 $merchant_id = ''; //INSERT MERCHANT ID (must be a 9 digit string)
 $api_key = ''; //INSERT API ACCESS PASSCODE
 $api_version = 'v1'; //default
-$platform = 'www'; //default
+$platform = 'api'; //default (or use 'tls12-api' for the TLS 1.2-Only endpoint)
 
 
 //generate a random order number, and set a default $amount (only used for example functions)
@@ -245,3 +245,4 @@ try {
      print_r($e);
      
 }
+?></pre>


### PR DESCRIPTION
Updated `src/Beanstream/communications/Endpoints.php`:
* Included support for `na.bambora.com` endpoints when `$platform = 'api'` (new default).
* Preserved backwards-compatibility with `beanstream.com` endpoints when `$platform = 'www'` (old default).

Updated `src/Beanstream/Configuration.php`:
* Changed default `$_platform` value to `'api'` from `'www'` for when the Gateway object is created without a `$platform` value.

Updated `src/Beanstream/examples.php`:
* Changed default `$platform` value to `'api'` from `'www'` which will send example requests to the `api.na.bambora.com` endpoints. Also added a comment to assist with TLS 1.2-Only testing.

Updated `README.md`:
* Added information related to backwards-compatibility with the `beanstream.com` endpoints.
* Added information related to TLS 1.2-Only integration tests.
* Added HTML formatting by wrapping result in `<pre></pre>`
